### PR TITLE
Remove older versions of golang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 
 go:
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - stable


### PR DESCRIPTION
Crypto library depends on math/bits, introduced in golang 1.9