### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/hdwallet.go
+++ b/hdwallet.go
@@ -140,7 +140,7 @@ func StringChild(data string, i uint32) (string, error) {
 	}
 }
 
-//StringToAddress returns the Bitcoin address of a base58-encoded extended key.
+//StringAddress returns the Bitcoin address of a base58-encoded extended key.
 func StringAddress(data string) (string, error) {
 	w, err := StringWallet(data)
 	if err != nil {


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?